### PR TITLE
add frontend config file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,8 @@ var styles = [
 ];
 
 module.exports = function(grunt) {
+	scripts.unshift(grunt.option('configPath') || 'src/js/defaultConfig.js');
+
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		clean: {

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ In order to build the static files you have to run grunt tasks which will genera
 grunt poa
 ```
 
+To build the static files for a network other than Ethereum copy and change src/js/defaultConfig.js and run the following command.
+
+```bash
+grunt poa --configPath="src/js/someOtherConfig.js"
+```
+
 #### Run
 Start a node process and pass the websocket secret to it.
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,6 +4,11 @@
 
 var netStatsApp = angular.module('netStatsApp', ['netStatsApp.filters', 'netStatsApp.directives', 'ngStorage']);
 
+netStatsApp.run(function($rootScope) {
+	$rootScope.networkName = networkName || 'Ethereum';
+	$rootScope.faviconPath = faviconPath || '/favicon.ico';
+});
+
 
 /* Services */
 

--- a/src/js/defaultConfig.js
+++ b/src/js/defaultConfig.js
@@ -1,0 +1,2 @@
+var networkName = 'Ethereum';
+var faviconPath = '/favicon.ico';

--- a/src/pow/views/layout.jade
+++ b/src/pow/views/layout.jade
@@ -3,12 +3,12 @@ doctype html
 html(ng-app="netStatsApp")
   head
     meta(name="viewport", content="width=device-width, initial-scale=1.0, maximum-scale=1.0")
-    title Ethereum Network Status
+    title {{ $root.networkName }} Network Status
     style(type="text/css") [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
     link(rel='stylesheet', href='/css/netstats.min.css')
     meta(name='robots', content='index,follow')
     meta(name='googlebot', content='index,follow')
-    link(rel='shortcut icon', type="image/x-icon", href="/favicon.ico")
+    link(rel='shortcut icon', type="image/x-icon", href="{{$root.faviconPath}}")
   body
     block content
     script(src="/js/netstats.min.js")

--- a/src/views/layout.jade
+++ b/src/views/layout.jade
@@ -3,12 +3,12 @@ doctype html
 html(ng-app="netStatsApp")
   head
     meta(name="viewport", content="width=device-width, initial-scale=1.0, maximum-scale=1.0")
-    title Testnet Network Status
+    title {{ $root.networkName }} Network Status
     style(type="text/css") [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
     link(rel='stylesheet', href='/css/netstats.min.css')
     meta(name='robots', content='index,follow')
     meta(name='googlebot', content='index,follow')
-    link(rel='shortcut icon', type="image/x-icon", href="/favicon.ico")
+    link(rel='shortcut icon', type="image/x-icon", href="{{$root.faviconPath}}")
   body
     block content
     script(src="/js/netstats.min.js")


### PR DESCRIPTION
This adds a `defaultConfig.js` file with two variables `networkName` and `faviconPath` for the frontend. To configure those variable `defaultConfig.js` can be changed (not recommended) or the `grunt poa --configPath="src/js/someOtherConfig.js"` can be used to point to another config file.

I struggled doing this in a more elegant way, like using ENV vars with grunt that and up in the frontend somehow or something..