### PR TITLE
Harden against missing transactions property

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -606,7 +606,7 @@ History.prototype.getCharts = function()
 					blocktime: item.block.time / 1000,
 					difficulty: item.block.difficulty,
 					uncles: item.block.uncles.length,
-					transactions: item.block.transactions.length,
+					transactions: item.block.transactions ? item.block.transactions.length : 0,
 					gasSpending: item.block.gasUsed,
 					gasLimit: item.block.gasLimit,
 					miner: item.block.miner


### PR DESCRIPTION
Should fix this:
2019-02-21 19:40:46.825 [API] [BLK] Block: 119134 td: 205248 from: blockchainsLlcPantheon ip: 10.240.0.7
2019-02-21 19:40:46.866 [API] [BLK] Block: 119137 td: 205254 from: Mudit-node-1 ip: 10.240.0.7
2019-02-21 19:40:46.867 [API] [STA] Stats from: Mudit-node-1
/app/ethstats-server/lib/history.js:609
transactions: item.block.transactions.length,
^

TypeError: Cannot read property 'length' of null