### PR TITLE
Limit connections in a window to prevent OOM

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -3,6 +3,9 @@ var app = express();
 var path = require('path');
 var bodyParser = require('body-parser');
 
+const v8 = require('node:v8');
+const fs  = require('node:fs');
+
 // view engine setup
 app.set('views', path.join(__dirname, (process.env.LITE === 'true' ? '../src-lite/views' : '../src/views')));
 app.set('view engine', 'pug');
@@ -22,8 +25,6 @@ async function writeHeapdump(filepath){
   try{
     writingHeapdump = true
     // Lazily import node modules
-    const fs = await import("node:fs");
-    const v8 = await import("v8");
     const snapshotStream = v8.getHeapSnapshot();
 
     const fileStream = fs.createWriteStream(filepath);

--- a/lib/express.js
+++ b/lib/express.js
@@ -10,6 +10,42 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, (process.env.LITE === 'true' ? '../dist-lite' : '../dist'))));
 
+
+let writingHeapdump = false;
+async function writeHeapdump(filepath){
+	// Check is anything is being written already
+  if(writingHeapdump){
+    console.log("already writing a snapshot, trigger once done");
+    return
+  }
+
+  try{
+    writingHeapdump = true
+    // Lazily import node modules
+    const fs = await import("node:fs");
+    const v8 = await import("v8");
+    const snapshotStream = v8.getHeapSnapshot();
+
+    const fileStream = fs.createWriteStream(filepath);
+    await new Promise<void>((resolve) => {
+      snapshotStream.pipe(fileStream);
+      snapshotStream.on("end", () => {
+        resolve();
+      });
+    });
+    return {data: {filepath}};
+  }finally{
+    writingHeapdump = false;
+  }
+}
+
+app.get('/snapshot',function(req,res){
+  const filepath = `${new Date().toISOString()}.heapsnapshot`;
+  console.log("triggering snapshot",{filepath});
+	void writeHeapdump(filepath);
+	res.json({filepath})
+})
+
 app.get('/', function(req, res) {
   res.render('index');
 });


### PR DESCRIPTION
ethstats server OOMs with supposedly data overload when too many connections connect with gc getting overwhelmed. a stop gap fix is to limit the connections accepted in the window although a deeper analysis and fix could be performed

This PR limits the new connections to 3 per 90 sec window.


one may test the pR with image: `g11tech/ethstats-server:limitcon`