### PR TITLE
Fix array range issues when max block is in hex format

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -644,7 +644,7 @@ History.prototype.getHistoryRequestRange = function()
 
 	var blocks = _.map( this._items, 'height' );
 	var best = _.max( blocks );
-	var range = _.range( _.max([ 0, best - MAX_HISTORY ]), best + 1);
+	var range = _.range( _.max([ 0, Number(best) - MAX_HISTORY ]), Number(best) + 1);
 
 	var missing = _.difference( range, blocks );
 


### PR DESCRIPTION
Some blockchain clients, which have embedded `ethstats-client` (Besu in my case) send block number information in hex format. This represents an issue as this `range` function doesn't do any hex to int conversion.      
ATM, if `best` is in hex format, the server will error out with `Array out of bounds` or similar errors.     
This tiny PR aims to fix that.